### PR TITLE
Lesson 05.03 Changes

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -33,6 +33,16 @@
                     "type": {
                         "numeric": true
                     }
+                },
+                "fillColor": {
+                    "displayName": "Fill Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -115,6 +115,35 @@ export class Visual implements IVisual {
      *
      */
     public enumerateObjectInstances(options: EnumerateVisualObjectInstancesOptions): VisualObjectInstance[] | VisualObjectInstanceEnumerationObject {
-        return VisualSettings.enumerateObjectInstances(this.settings || VisualSettings.getDefault(), options);
+        let objects = <VisualObjectInstanceEnumerationObject>
+                VisualSettings.enumerateObjectInstances(
+                    this.settings || VisualSettings.getDefault(),
+                    options
+                );
+        // Show which object this call is processing
+            console.log(`Object: ${options.objectName}`);
+        // Based on which object we're working with, handle the instances accordingly
+            switch (options.objectName) {
+                case 'dataPoints': {
+                    // Create a new instance for each group/series and add data-bound properties
+                        this.viewModelManager.viewModel.categories[0].groups.forEach((g) => {
+                            objects.instances.push({
+                                objectName: options.objectName,
+                                displayName: g.name,
+                                properties: {
+                                    fillColor: {
+                                        solid: {
+                                            color: g.color
+                                        }
+                                    }
+                                },
+                                selector: g.groupSelectionId.getSelector()
+                            });
+                        });
+                }
+            }
+        // Show our instances
+            console.log(objects.instances);
+        return objects;
     }
 }


### PR DESCRIPTION
- Added 'template' property to capabilities for data point fill color
- Updated ViewModel to group categorical.values and resolve fillColor from the resulting objects (if present) and assign the theme's next default if not (previous functionality)
- Added logic for enumerateObjectInstances to push an instance for each category group (series) so that the dataPoints object in the properties pane has a fillColor property for each