### PR TITLE
Lesson 05.09 Changes

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -116,5 +116,11 @@
                 }
             }
         }
-    ]
+    ],
+    "tooltips": {
+        "supportedTypes": {
+            "default": true,
+            "canvas": true
+        }
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,6 +1229,14 @@
         }
       }
     },
+    "powerbi-visuals-utils-tooltiputils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/powerbi-visuals-utils-tooltiputils/-/powerbi-visuals-utils-tooltiputils-2.4.0.tgz",
+      "integrity": "sha512-4ATuPVXKfgSGZ3VA7SdtQhI1gyv7CNRzXMYlVdnJLi6ZMHj3/UClid4C7pEo8uXE6jyWJ68LRBySOowlUxgOpA==",
+      "requires": {
+        "d3-selection": "^1.4.1"
+      }
+    },
     "powerbi-visuals-utils-typeutils": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/powerbi-visuals-utils-typeutils/-/powerbi-visuals-utils-typeutils-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "d3": "5.12.0",
     "powerbi-visuals-api": "~2.6.1",
     "powerbi-visuals-utils-dataviewutils": "2.2.1",
-    "powerbi-visuals-utils-interactivityutils": "^5.7.0"
+    "powerbi-visuals-utils-interactivityutils": "^5.7.0",
+    "powerbi-visuals-utils-tooltiputils": "^2.4.0"
   },
   "devDependencies": {
     "ts-loader": "6.1.0",

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -6,7 +6,7 @@ import IInteractiveBehavior = interactivityBaseService.IInteractiveBehavior;
 import ISelectionHandler = interactivityBaseService.ISelectionHandler;
 import getEvent = interactivityUtils.getEvent;
 
-import { ICategory, IGroup, IGroupBase } from './viewModel';
+import { ICategory, IGroupDataPoint, IGroupBase } from './viewModel';
 
 /**
  * Behavior options for interactivity.
@@ -15,7 +15,7 @@ import { ICategory, IGroup, IGroupBase } from './viewModel';
         // Elements denoting a selectable category in the visual
             categorySelection: d3.Selection<any, ICategory, any, any>;
         // Elements denoting a selectable data point in the visual
-            pointSelection: d3.Selection<SVGCircleElement, IGroup, any, ICategory>;
+            pointSelection: d3.Selection<SVGCircleElement, IGroupDataPoint, any, ICategory>;
         // Elements denotic a selectable data label in the visual
             dataLabelSelection: d3.Selection<SVGTextElement, IGroupBase, any, any>;
         // Elements denoting a selectable category label in the visual

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -5,7 +5,7 @@ import * as d3Select from 'd3-selection';
 import * as d3Axis from 'd3-axis';
 
 import { ConnectingLineSettings } from './settings';
-import { IViewModel, ICategory, IGroup, IGroupBase } from './viewModel';
+import { IViewModel, ICategory, IGroupDataPoint, IGroupBase } from './viewModel';
 
     export class ChartManager {
 
@@ -22,7 +22,7 @@ import { IViewModel, ICategory, IGroup, IGroupBase } from './viewModel';
         // Category elements, as bound by D3
             categories: d3Select.Selection<SVGLineElement, ICategory, any, any>;
         // Individual group elements, as bound by D3
-            points: d3.Selection<SVGCircleElement, IGroup, any, ICategory>;
+            points: d3.Selection<SVGCircleElement, IGroupDataPoint, any, ICategory>;
         // Data label elements, as bound by D3
             dataLabels: d3.Selection<SVGTextElement, IGroupBase, any, any>;
         // Category axis label elements, as bound by D3
@@ -259,7 +259,7 @@ import { IViewModel, ICategory, IGroup, IGroupBase } from './viewModel';
          * @param radius        - circle radius, in px
          */
             private transformDumbbellCircle(
-                selection: d3.Selection<SVGCircleElement, IGroup, any, any>,
+                selection: d3.Selection<SVGCircleElement, IGroupDataPoint, any, any>,
                 categoryScale: d3.ScaleBand<string>,
                 valueScale: d3.ScaleLinear<number, number>,
                 radius: number
@@ -281,7 +281,7 @@ import { IViewModel, ICategory, IGroup, IGroupBase } from './viewModel';
          * @param show          - whether to show labels or not
          */
             private transformDataLabel(
-                selection: d3.Selection<SVGTextElement, IGroup, any, any>,
+                selection: d3.Selection<SVGTextElement, IGroupDataPoint, any, any>,
                 valueScale: d3.ScaleLinear<number, number>,
                 show: boolean
             ) {

--- a/src/viewModel.ts
+++ b/src/viewModel.ts
@@ -7,6 +7,7 @@ import { dataViewObject } from 'powerbi-visuals-utils-dataviewutils';
 import getFillColorByPropertyName = dataViewObject.getFillColorByPropertyName;
 import { interactivitySelectionService } from 'powerbi-visuals-utils-interactivityutils';
 import SelectableDataPoint = interactivitySelectionService.SelectableDataPoint;
+import VisualTooltipDataItem = powerbi.extensibility.VisualTooltipDataItem;
 
 import { VisualSettings } from './settings';
 
@@ -85,7 +86,7 @@ import * as d3Scale from 'd3-scale';
 /**
  * Represents a data point within a visual category.
  */
-    export interface IGroup extends IGroupBase {
+    export interface IGroupDataPoint extends IGroupBase {
         // Name of group
             name: string;
         // Group selection ID (for unique values of series)
@@ -94,6 +95,8 @@ import * as d3Scale from 'd3-scale';
             dataPointSelectionId: ISelectionId;
         // Data point color
             color: string;
+        // Default tooltip data
+            tooltipData: VisualTooltipDataItem[];
     }
 
 /**
@@ -109,7 +112,7 @@ import * as d3Scale from 'd3-scale';
         // Category selection ID
             selectionId: ISelectionId;
         // Category group items
-            groups: IGroup[];
+            groups: IGroupDataPoint[];
     }
 
 /**
@@ -192,7 +195,7 @@ import * as d3Scale from 'd3-scale';
                             // The number of entries in the categorical.values array denotes how many groups we have in each
                             // category, so we can iterate over these too and use the category index from the outer foreach
                             // to access the correct measure value from each group's values array.
-                                const groups: IGroup[] = valueGroupings.grouped().map((g, gi) => {
+                                const groups: IGroupDataPoint[] = valueGroupings.grouped().map((g, gi) => {
                                     // Get our measure column (which is the first values array element)
                                         const measure = g.values.find((m) => m.source.roles.measure);
                                     // Get group name
@@ -222,6 +225,15 @@ import * as d3Scale from 'd3-scale';
                                             'fillColor',
                                             this.host.colorPalette.getColor(groupName).value
                                         );
+                                    // Add tooltip data
+                                        let tooltipData: VisualTooltipDataItem[] = [
+                                            {
+                                                header: `${categoryName} - ${groupName}`,
+                                                displayName: measure.source.displayName,
+                                                value: `${groupValue}`,
+                                                color: color
+                                            }
+                                        ];
                                     // On the first pass through categories, make sure that our distinct group list is populated
                                         if (ci === 0) {
                                             viewModel.groups.push({
@@ -241,7 +253,8 @@ import * as d3Scale from 'd3-scale';
                                             value: groupValue,
                                             color: color,
                                             identity: dataPointSelectionId,
-                                            selected: false
+                                            selected: false,
+                                            tooltipData: tooltipData
                                         }
                                 });
                         // Resolve dataset min/max based on discovered group min/max


### PR DESCRIPTION
- Added powerbi-visuals-utils-tooltiputils
- Enabled tooltip support via capabilities
- Renamed IGroup to IGroupDataPoint
- Added tooltip service wrapper to visual
- Extended ViewModel to store default tooltip data for IGroupDataPoint objects
- Added tooltip binding to visual for default and report page tooltips