### PR TITLE
Lesson 06.07 Changes

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -47,12 +47,70 @@
                             }
                         ]
                     }
+                },
+                "innerPadding": {
+                    "displayName": "Inner Padding",
+                    "type": {
+                        "integer": true
+                    }
+                },
+                "color": {
+                    "displayName": "Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
+                },
+                "fontSize": {
+                    "displayName": "Text Size",
+                    "type": {
+                        "formatting": {
+                            "fontSize": true
+                        }
+                    }
+                },
+                "fontFamily": {
+                    "displayName": "Font Family",
+                    "type": {
+                        "formatting": {
+                            "fontFamily": true
+                        }
+                    }
                 }
             }
         },
         "valueAxis": {
             "displayName": "Measure Axis",
             "properties": {
+                "color": {
+                    "displayName": "Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
+                },
+                "fontSize": {
+                    "displayName": "Text Size",
+                    "type": {
+                        "formatting": {
+                            "fontSize": true
+                        }
+                    }
+                },
+                "fontFamily": {
+                    "displayName": "Font Family",
+                    "type": {
+                        "formatting": {
+                            "fontFamily": true
+                        }
+                    }
+                },
                 "displayUnits": {
                     "displayName": "Display Units",
                     "type": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,12 +39,23 @@ export class VisualSettings extends DataViewObjectsParser {
     dataLabels = new DataLabelSettings();
 }
 
-export class CategoryAxisSettings {
-    // Specifies orientation of the axis in the visual
-        orientation: AxisOrientation = 'left';
+export class AxisSettings {
+    // Tick label color
+        color: string = '#605E5C';
+    // Tick label font size
+        fontSize: number = 9;
+    // Tick label font family
+        fontFamily: string = '"Segoe UI", wf_segoe-ui_normal, helvetica, arial, sans-serif';
 }
 
-export class ValueAxisSettings {
+export class CategoryAxisSettings extends AxisSettings {
+    // Specifies orientation of the axis in the visual
+        orientation: AxisOrientation = 'left';
+    // Inner padding between categories
+        innerPadding: number = 20;
+}
+
+export class ValueAxisSettings extends AxisSettings {
     // Display units for axis values
         displayUnits: number = 0;
     // Number of decimal places to use for values

--- a/style/visual.less
+++ b/style/visual.less
@@ -6,7 +6,6 @@
 }
 
 .axis .tick text {
-    fill: #605E5C;
     stroke: none;
 }
 


### PR DESCRIPTION
- Added font properties for axis tick labels
- Added logic to ViewModel to calculate margin sizes based on measured tick labels
- Applied font styling to axis tick labels
- Added inner padding property to category axis scale
- Ensured that if category labels are bottom-oriented and exceed bandwidth, then they are truncated
- Added tooltip to category tick labels