### PR TITLE
Lesson 06.09 Changes

### DIFF
--- a/src/viewModel.ts
+++ b/src/viewModel.ts
@@ -483,7 +483,10 @@ import * as d3Scale from 'd3-scale';
                         scale: d3Scale.scaleBand()
                             .domain(categoryAxisDomain)
                             .range(categoryAxisRange)
-                            .padding(this.viewModel.settings.categoryAxis.innerPadding / 100),
+                            .padding(orientation === 'left'
+                                ?   0
+                                :   this.viewModel.settings.categoryAxis.innerPadding / 100
+                            ),
                         translate: categoryAxisTranslate,
                         tickTextProperties: categoryAxisTickTextProperties,
                         tickLabelDimensions: categoryTickLabelDimensions

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -180,6 +180,10 @@ export class Visual implements IVisual {
                                 }
                             }
                         }
+                    // Remove inner padding if using left orientation
+                        if (this.settings.categoryAxis.orientation === 'left') {
+                            delete objects.instances[0].properties.innerPadding;
+                        }
                     break;
                 }
                 case 'valueAxis': {


### PR DESCRIPTION
- Conditionally hide Inner Padding in the properties pane if the orientation is set to 'left'
- Set the category axis scale padding to 0 if orientation is set to 'left'